### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-
 FROM alpine:latest
 
+RUN apk add --update
+
+RUN apk add py3-setuptools
+
+RUN apk add python2
+
 RUN apk add --update \
-    python \
     groff \
-    py2-pip && \
+    py-pip && \
     adduser -D aws
 
 ENV PAGER='cat'


### PR DESCRIPTION
mods to work with Fedora CoreOS since standard CoreOS went EOL (at least for me, without these changes it stopped working).